### PR TITLE
Add CLI for generating FFXIV themed football pyramids

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,105 @@
-# EFL
+# FFXIV Football Pyramid Builder
+
+Create custom English-style football pyramids inspired by Final Fantasy XIV regions. The
+command line tool included in this repository focuses on fast iteration so you can spin
+up a structure, review the clubs, tweak the tiers, and re-roll ideas in just a few
+commands.
+
+## Features
+
+- Three curated themes (`eorzea`, `far_east`, `garlemald`) with lore-friendly division
+  titles, locations, and inspirations.
+- Instant pyramid generation from a single command: specify the number of teams per level
+  and receive a ready-to-use JSON description.
+- Built-in preview mode to quickly inspect a concept without writing files.
+- Resample command that reuses metadata from an existing pyramid to experiment with new
+  seeds, level sizes, or themes in seconds.
+- Human-readable JSON output that can be version controlled or edited manually for
+  bespoke tweaks.
+
+## Getting started
+
+1. Ensure you are using Python 3.10+ (the repo is configured for Python 3.12).
+2. No additional dependencies are required—everything runs with the Python standard
+   library.
+3. Generate your first pyramid:
+
+   ```bash
+   python -m ffxiv_pyramid.cli generate builds/my_pyramid.json --levels 12 12 18 24 --theme eorzea --title "Hydaelyn League System"
+   ```
+
+   Use `--preview` to see the output without writing to disk.
+
+## Repository layout
+
+- `ffxiv_pyramid/` – source package containing the data sets, generator logic, and CLI.
+- `examples/eorzea_pyramid.json` – sample four-tier pyramid showcasing the JSON schema.
+
+## Commands
+
+### List available themes
+
+```bash
+python -m ffxiv_pyramid.cli themes
+```
+
+### Generate a new pyramid
+
+```bash
+python -m ffxiv_pyramid.cli generate builds/garlean_ladder.json --levels 18 18 24 --theme garlemald --title "Imperial Revival Pyramid" --description "League play for the liberated provinces."
+```
+
+- `--levels` (required): number of clubs in each tier starting from the top.
+- `--theme`: pick the flavour set (`eorzea`, `far_east`, or `garlemald`).
+- `--division-name`: override division names (provide once per level, e.g. `--division-name "Crystal Premier" --division-name "Source Championship"`).
+- `--seed`: ensure repeatable results.
+- `--preview`: print the pyramid without saving to disk.
+
+### Resample using an existing pyramid
+
+Keep the same structure but explore different seeds, level sizes, or even themes.
+
+```bash
+python -m ffxiv_pyramid.cli resample examples/eorzea_pyramid.json --seed 9876 --preview
+```
+
+You can also switch themes or change tiers without touching JSON manually:
+
+```bash
+python -m ffxiv_pyramid.cli resample examples/eorzea_pyramid.json --theme far_east --levels 16 18 24 --output builds/far_east_variant.json
+```
+
+### Show a pyramid file
+
+```bash
+python -m ffxiv_pyramid.cli show examples/eorzea_pyramid.json
+```
+
+Add `--no-teams` for a condensed overview of the structure.
+
+## JSON schema overview
+
+Each generated file is a UTF-8 encoded JSON document with the following top-level
+properties:
+
+- `title` / `description`: plain text metadata you can edit manually.
+- `generated_at`: timestamp (UTC) of the generation run.
+- `meta`: dictionary capturing the seed, level sizes, chosen theme, and additional notes
+  (used by the `resample` command).
+- `divisions`: ordered array from the top tier downward. Each division contains `level`,
+  `name`, `short_name`, and a `teams` list. Every team entry has a lore location,
+  inspiration, and optional notes.
+
+Feel free to tweak the JSON directly—`python -m ffxiv_pyramid.cli show` will reflect your
+changes immediately.
+
+## Rapid iteration tips
+
+- Rerun `generate` with different `--seed` values to explore alternative club rosters
+  while keeping the same structure.
+- Use `resample` to branch off variants of your favourite setups without destroying the
+  original file.
+- Store multiple JSON files in `builds/` or `examples/` and compare them with `git diff`
+  to track the evolution of your pyramid concepts.
+
+Happy league building, Warrior of Light!

--- a/examples/eorzea_pyramid.json
+++ b/examples/eorzea_pyramid.json
@@ -1,0 +1,443 @@
+{
+  "title": "Hydaelyn League System",
+  "description": "An example four-tier pyramid spanning the Source.",
+  "generated_at": "2025-09-21T13:03:11.689646",
+  "meta": {
+    "theme": "eorzea",
+    "seed": 123,
+    "levels": [
+      12,
+      12,
+      18,
+      24
+    ],
+    "short_prefix": "EFL",
+    "generated_using": "ffxiv_pyramid"
+  },
+  "divisions": [
+    {
+      "level": 1,
+      "name": "Eorzean Premier League",
+      "short_name": "EFL L1",
+      "teams": [
+        {
+          "name": "Garlemald Reclaimed Radiant Dragoons",
+          "location": "Garlemald Reclaimed",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Hails from Garlemald Reclaimed with Radz-at-Han alchemists influence."
+        },
+        {
+          "name": "Gridania Radiant Dawn",
+          "location": "Gridania",
+          "inspiration": "Sharlayan Forum",
+          "notes": "Hails from Gridania with Sharlayan Forum influence."
+        },
+        {
+          "name": "Gridania Radiant Sky Pirates",
+          "location": "Gridania",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Hails from Gridania with Radz-at-Han alchemists influence."
+        },
+        {
+          "name": "Lakeland Twin Adders",
+          "location": "Lakeland",
+          "inspiration": "Bozjan Resistance",
+          "notes": "Founded by veterans of the Bozjan Resistance."
+        },
+        {
+          "name": "Limsa Lominsa Astral Sky Pirates",
+          "location": "Limsa Lominsa",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Backed by the Ishgardian Restoration from Limsa Lominsa."
+        },
+        {
+          "name": "Limsa Lominsa Rising Carbuncle",
+          "location": "Limsa Lominsa",
+          "inspiration": "Temple Knights",
+          "notes": "Backed by the Temple Knights from Limsa Lominsa."
+        },
+        {
+          "name": "Old Sharlayan Blades",
+          "location": "Old Sharlayan",
+          "inspiration": "Scions of the Seventh Dawn",
+          "notes": "Club culture steeped in Scions of the Seventh Dawn tradition."
+        },
+        {
+          "name": "Radz-at-Han Starlit Temple Knights",
+          "location": "Radz-at-Han",
+          "inspiration": "Maelstrom",
+          "notes": "Founded by veterans of the Maelstrom."
+        },
+        {
+          "name": "The Dravanian Forelands Adders",
+          "location": "The Dravanian Forelands",
+          "inspiration": "Sharlayan Forum",
+          "notes": "Club culture steeped in Sharlayan Forum tradition."
+        },
+        {
+          "name": "Ul'dah Conjurers",
+          "location": "Ul'dah",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Club culture steeped in Ishgardian Restoration tradition."
+        },
+        {
+          "name": "Ul'dah Mythril Temple Knights",
+          "location": "Ul'dah",
+          "inspiration": "Scions of the Seventh Dawn",
+          "notes": "Club culture steeped in Scions of the Seventh Dawn tradition."
+        },
+        {
+          "name": "Ul'dah Starlit Scions",
+          "location": "Ul'dah",
+          "inspiration": "Order of the Twin Adder",
+          "notes": "Backed by the Order of the Twin Adder from Ul'dah."
+        }
+      ]
+    },
+    {
+      "level": 2,
+      "name": "Grand Company Championship",
+      "short_name": "EFL L2",
+      "teams": [
+        {
+          "name": "Coerthas Radiant Dawn",
+          "location": "Coerthas",
+          "inspiration": "Order of the Twin Adder",
+          "notes": "Backed by the Order of the Twin Adder from Coerthas."
+        },
+        {
+          "name": "Garlemald Reclaimed Sky Pirates",
+          "location": "Garlemald Reclaimed",
+          "inspiration": "Students of Baldesion",
+          "notes": "Hails from Garlemald Reclaimed with Students of Baldesion influence."
+        },
+        {
+          "name": "Garlemald Reclaimed Sky Pirates Guard",
+          "location": "Garlemald Reclaimed",
+          "inspiration": "Crystarium Guard",
+          "notes": "Backed by the Crystarium Guard from Garlemald Reclaimed."
+        },
+        {
+          "name": "Gridania Gobwalkers",
+          "location": "Gridania",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Backed by the Radz-at-Han alchemists from Gridania."
+        },
+        {
+          "name": "Gridania Temple Knights",
+          "location": "Gridania",
+          "inspiration": "Temple Knights",
+          "notes": "Club culture steeped in Temple Knights tradition."
+        },
+        {
+          "name": "Idyllshire Gobwalkers",
+          "location": "Idyllshire",
+          "inspiration": "Crystarium Guard",
+          "notes": "Backed by the Crystarium Guard from Idyllshire."
+        },
+        {
+          "name": "Old Sharlayan Twin Gobwalkers",
+          "location": "Old Sharlayan",
+          "inspiration": "Immortal Flames",
+          "notes": "Hails from Old Sharlayan with Immortal Flames influence."
+        },
+        {
+          "name": "Radz-at-Han Temple Knights",
+          "location": "Radz-at-Han",
+          "inspiration": "Students of Baldesion",
+          "notes": "Backed by the Students of Baldesion from Radz-at-Han."
+        },
+        {
+          "name": "Thanalan Crystalline Conjurers",
+          "location": "Thanalan",
+          "inspiration": "Maelstrom",
+          "notes": "Hails from Thanalan with Maelstrom influence."
+        },
+        {
+          "name": "The Crystarium Free Paladins",
+          "location": "The Crystarium",
+          "inspiration": "Order of the Twin Adder",
+          "notes": "Club culture steeped in Order of the Twin Adder tradition."
+        },
+        {
+          "name": "The Dravanian Forelands Carbuncle",
+          "location": "The Dravanian Forelands",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Club culture steeped in Radz-at-Han alchemists tradition."
+        },
+        {
+          "name": "Ul'dah Starlit Temple Knights",
+          "location": "Ul'dah",
+          "inspiration": "Order of the Twin Adder",
+          "notes": "Backed by the Order of the Twin Adder from Ul'dah."
+        }
+      ]
+    },
+    {
+      "level": 3,
+      "name": "Eorzean City-State Division I",
+      "short_name": "EFL L3",
+      "teams": [
+        {
+          "name": "Coerthas Adders",
+          "location": "Coerthas",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Club culture steeped in Ishgardian Restoration tradition."
+        },
+        {
+          "name": "Garlemald Reclaimed Heavensward Gobwalkers",
+          "location": "Garlemald Reclaimed",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Backed by the Ishgardian Restoration from Garlemald Reclaimed."
+        },
+        {
+          "name": "Gridania Stormborn Nald'thal",
+          "location": "Gridania",
+          "inspiration": "Order of the Twin Adder",
+          "notes": "Club culture steeped in Order of the Twin Adder tradition."
+        },
+        {
+          "name": "Gridania Umbral Gobwalkers",
+          "location": "Gridania",
+          "inspiration": "Bozjan Resistance",
+          "notes": "Hails from Gridania with Bozjan Resistance influence."
+        },
+        {
+          "name": "Idyllshire Adders",
+          "location": "Idyllshire",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Backed by the Radz-at-Han alchemists from Idyllshire."
+        },
+        {
+          "name": "Idyllshire Sky Pirates",
+          "location": "Idyllshire",
+          "inspiration": "Bozjan Resistance",
+          "notes": "Club culture steeped in Bozjan Resistance tradition."
+        },
+        {
+          "name": "Kugane Conjurers",
+          "location": "Kugane",
+          "inspiration": "Scions of the Seventh Dawn",
+          "notes": "Club culture steeped in Scions of the Seventh Dawn tradition."
+        },
+        {
+          "name": "Lakeland Radiant Dawn",
+          "location": "Lakeland",
+          "inspiration": "Students of Baldesion",
+          "notes": "Club culture steeped in Students of Baldesion tradition."
+        },
+        {
+          "name": "Mor Dhona Ruby Astrologians",
+          "location": "Mor Dhona",
+          "inspiration": "Scions of the Seventh Dawn",
+          "notes": "Hails from Mor Dhona with Scions of the Seventh Dawn influence."
+        },
+        {
+          "name": "Old Gridania Radiant Scions",
+          "location": "Old Gridania",
+          "inspiration": "Sharlayan Forum",
+          "notes": "Hails from Old Gridania with Sharlayan Forum influence."
+        },
+        {
+          "name": "Radz-at-Han Blades",
+          "location": "Radz-at-Han",
+          "inspiration": "Immortal Flames",
+          "notes": "Hails from Radz-at-Han with Immortal Flames influence."
+        },
+        {
+          "name": "Thanalan Crystalline Radiant Dawn",
+          "location": "Thanalan",
+          "inspiration": "Immortal Flames",
+          "notes": "Club culture steeped in Immortal Flames tradition."
+        },
+        {
+          "name": "Thavnair Gobwalkers",
+          "location": "Thavnair",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Backed by the Ishgardian Restoration from Thavnair."
+        },
+        {
+          "name": "Thavnair Seedseers",
+          "location": "Thavnair",
+          "inspiration": "Maelstrom",
+          "notes": "Founded by veterans of the Maelstrom."
+        },
+        {
+          "name": "Thavnair Stormborn Adders",
+          "location": "Thavnair",
+          "inspiration": "Immortal Flames",
+          "notes": "Hails from Thavnair with Immortal Flames influence."
+        },
+        {
+          "name": "The Crystarium Conjurers",
+          "location": "The Crystarium",
+          "inspiration": "Maelstrom",
+          "notes": "Founded by veterans of the Maelstrom."
+        },
+        {
+          "name": "The Dravanian Forelands Rising Blades",
+          "location": "The Dravanian Forelands",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Hails from The Dravanian Forelands with Ishgardian Restoration influence."
+        },
+        {
+          "name": "Ul'dah Free Paladins",
+          "location": "Ul'dah",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Founded by veterans of the Radz-at-Han alchemists."
+        }
+      ]
+    },
+    {
+      "level": 4,
+      "name": "Eorzean City-State Division II",
+      "short_name": "EFL L4",
+      "teams": [
+        {
+          "name": "Coerthas Mythril Chocobos",
+          "location": "Coerthas",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Hails from Coerthas with Ishgardian Restoration influence."
+        },
+        {
+          "name": "Gridania Radiant Dawn FC",
+          "location": "Gridania",
+          "inspiration": "Scions of the Seventh Dawn",
+          "notes": "Founded by veterans of the Scions of the Seventh Dawn."
+        },
+        {
+          "name": "Idyllshire Gobwalkers United",
+          "location": "Idyllshire",
+          "inspiration": "Maelstrom",
+          "notes": "Founded by veterans of the Maelstrom."
+        },
+        {
+          "name": "Idyllshire Maelstrom",
+          "location": "Idyllshire",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Club culture steeped in Radz-at-Han alchemists tradition."
+        },
+        {
+          "name": "La Noscea Astral House Fortemps",
+          "location": "La Noscea",
+          "inspiration": "Temple Knights",
+          "notes": "Club culture steeped in Temple Knights tradition."
+        },
+        {
+          "name": "Labyrinthos Azure Drakes",
+          "location": "Labyrinthos",
+          "inspiration": "Bozjan Resistance",
+          "notes": "Hails from Labyrinthos with Bozjan Resistance influence."
+        },
+        {
+          "name": "Labyrinthos Carbuncle",
+          "location": "Labyrinthos",
+          "inspiration": "Sharlayan Forum",
+          "notes": "Club culture steeped in Sharlayan Forum tradition."
+        },
+        {
+          "name": "Labyrinthos Crystalline Blades",
+          "location": "Labyrinthos",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Founded by veterans of the Ishgardian Restoration."
+        },
+        {
+          "name": "Labyrinthos Radiant Adders",
+          "location": "Labyrinthos",
+          "inspiration": "Sharlayan Forum",
+          "notes": "Club culture steeped in Sharlayan Forum tradition."
+        },
+        {
+          "name": "Labyrinthos Twin Immortals",
+          "location": "Labyrinthos",
+          "inspiration": "Bozjan Resistance",
+          "notes": "Hails from Labyrinthos with Bozjan Resistance influence."
+        },
+        {
+          "name": "Lakeland Maelstrom",
+          "location": "Lakeland",
+          "inspiration": "Temple Knights",
+          "notes": "Club culture steeped in Temple Knights tradition."
+        },
+        {
+          "name": "Limsa Lominsa Astrologians",
+          "location": "Limsa Lominsa",
+          "inspiration": "Bozjan Resistance",
+          "notes": "Hails from Limsa Lominsa with Bozjan Resistance influence."
+        },
+        {
+          "name": "Limsa Lominsa Azure Drakes",
+          "location": "Limsa Lominsa",
+          "inspiration": "Crystarium Guard",
+          "notes": "Backed by the Crystarium Guard from Limsa Lominsa."
+        },
+        {
+          "name": "Limsa Lominsa Carbuncle",
+          "location": "Limsa Lominsa",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Founded by veterans of the Radz-at-Han alchemists."
+        },
+        {
+          "name": "Limsa Lominsa Dragoons",
+          "location": "Limsa Lominsa",
+          "inspiration": "Immortal Flames",
+          "notes": "Founded by veterans of the Immortal Flames."
+        },
+        {
+          "name": "Limsa Lominsa Twin Sky Pirates",
+          "location": "Limsa Lominsa",
+          "inspiration": "Temple Knights",
+          "notes": "Backed by the Temple Knights from Limsa Lominsa."
+        },
+        {
+          "name": "Mor Dhona Adders",
+          "location": "Mor Dhona",
+          "inspiration": "Crystarium Guard",
+          "notes": "Hails from Mor Dhona with Crystarium Guard influence."
+        },
+        {
+          "name": "Old Sharlayan Chocobos",
+          "location": "Old Sharlayan",
+          "inspiration": "Order of the Twin Adder",
+          "notes": "Club culture steeped in Order of the Twin Adder tradition."
+        },
+        {
+          "name": "Sharlayan Conjurers",
+          "location": "Sharlayan",
+          "inspiration": "Radz-at-Han alchemists",
+          "notes": "Founded by veterans of the Radz-at-Han alchemists."
+        },
+        {
+          "name": "Thanalan Eternal Conjurers",
+          "location": "Thanalan",
+          "inspiration": "Maelstrom",
+          "notes": "Club culture steeped in Maelstrom tradition."
+        },
+        {
+          "name": "Thavnair Flames",
+          "location": "Thavnair",
+          "inspiration": "Students of Baldesion",
+          "notes": "Backed by the Students of Baldesion from Thavnair."
+        },
+        {
+          "name": "The Crystarium Starlit Scions",
+          "location": "The Crystarium",
+          "inspiration": "Maelstrom",
+          "notes": "Backed by the Maelstrom from The Crystarium."
+        },
+        {
+          "name": "The Dravanian Forelands Nald'thal",
+          "location": "The Dravanian Forelands",
+          "inspiration": "Ishgardian Restoration",
+          "notes": "Founded by veterans of the Ishgardian Restoration."
+        },
+        {
+          "name": "The Dravanian Forelands Radiant Gobwalkers",
+          "location": "The Dravanian Forelands",
+          "inspiration": "Sharlayan Forum",
+          "notes": "Backed by the Sharlayan Forum from The Dravanian Forelands."
+        }
+      ]
+    }
+  ]
+}

--- a/ffxiv_pyramid/__init__.py
+++ b/ffxiv_pyramid/__init__.py
@@ -1,0 +1,4 @@
+"""FFXIV football pyramid builder package."""
+
+__all__ = ["cli", "data", "generator", "io", "model"]
+__version__ = "0.1.0"

--- a/ffxiv_pyramid/cli.py
+++ b/ffxiv_pyramid/cli.py
@@ -1,0 +1,228 @@
+"""Command line interface for the FFXIV football pyramid app."""
+from __future__ import annotations
+
+from argparse import ArgumentParser, Namespace
+import random
+from pathlib import Path
+from typing import Sequence
+from textwrap import indent
+
+from .data import THEMES
+from .generator import generate_pyramid
+from .io import load_pyramid, save_pyramid
+from .model import Pyramid
+
+
+def _build_parser() -> ArgumentParser:
+    parser = ArgumentParser(description="Create and iterate on FFXIV themed football pyramids.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # generate command
+    generate_parser = subparsers.add_parser(
+        "generate", help="Generate a brand new pyramid and optionally save it to disk."
+    )
+    generate_parser.add_argument("output", help="Path to save the generated pyramid (must end with .json).")
+    generate_parser.add_argument(
+        "--levels",
+        metavar="N",
+        type=int,
+        nargs="+",
+        required=True,
+        help="Number of clubs in each level from top to bottom (e.g. --levels 12 12 18).",
+    )
+    generate_parser.add_argument(
+        "--theme",
+        default="eorzea",
+        choices=sorted(THEMES.keys()),
+        help="Which FFXIV region should inspire the pyramid?",
+    )
+    generate_parser.add_argument("--title", help="Custom title for the pyramid.")
+    generate_parser.add_argument("--description", help="Optional descriptive blurb for the pyramid.")
+    generate_parser.add_argument("--seed", type=int, help="Seed for deterministic generation.")
+    generate_parser.add_argument(
+        "--division-name",
+        action="append",
+        dest="division_names",
+        help="Override the name for a level. Provide one per level in order.",
+    )
+    generate_parser.add_argument(
+        "--preview",
+        action="store_true",
+        help="Print the generated pyramid without writing to disk.",
+    )
+
+    # resample command
+    resample_parser = subparsers.add_parser(
+        "resample",
+        help="Re-roll a pyramid using the metadata in an existing file, optionally tweaking options.",
+    )
+    resample_parser.add_argument("source", help="Existing pyramid JSON file to use as a template.")
+    resample_parser.add_argument(
+        "--output",
+        help="Where to write the updated pyramid. Defaults to overwriting the source file.",
+    )
+    resample_parser.add_argument(
+        "--levels",
+        metavar="N",
+        type=int,
+        nargs="+",
+        help="Override level sizes while keeping the rest of the template.",
+    )
+    resample_parser.add_argument(
+        "--theme",
+        choices=sorted(THEMES.keys()),
+        help="Switch to a different theme without editing the file manually.",
+    )
+    resample_parser.add_argument("--seed", type=int, help="Optional new random seed.")
+    resample_parser.add_argument(
+        "--division-name",
+        action="append",
+        dest="division_names",
+        help="Override level names for the regenerated pyramid.",
+    )
+    resample_parser.add_argument("--title", help="Update the title while regenerating.")
+    resample_parser.add_argument("--description", help="Update the description while regenerating.")
+    resample_parser.add_argument(
+        "--preview",
+        action="store_true",
+        help="Preview the regenerated pyramid without writing to disk.",
+    )
+
+    # show command
+    show_parser = subparsers.add_parser("show", help="Pretty print the contents of a pyramid file.")
+    show_parser.add_argument("source", help="Path to the JSON pyramid file to display.")
+    show_parser.add_argument(
+        "--no-teams",
+        action="store_true",
+        help="Only show division names instead of listing every team.",
+    )
+
+    # themes command
+    subparsers.add_parser("themes", help="List all available themes and their highlights.")
+
+    return parser
+
+
+def _format_team_line(index: int, team_name: str, inspiration: str, location: str) -> str:
+    return f"{index:>2}. {team_name} — {location} ({inspiration})"
+
+
+def _print_pyramid(pyramid: Pyramid, *, show_teams: bool = True) -> None:
+    print(pyramid.title)
+    if pyramid.description:
+        print(pyramid.description)
+    if pyramid.meta:
+        meta_info = {
+            "Theme": pyramid.meta.get("theme"),
+            "Levels": pyramid.meta.get("levels"),
+            "Seed": pyramid.meta.get("seed"),
+        }
+        filtered = {key: value for key, value in meta_info.items() if value is not None}
+        if filtered:
+            print("Meta:")
+            for key, value in filtered.items():
+                print(f"  {key}: {value}")
+    if pyramid.generated_at:
+        print(f"Generated at: {pyramid.generated_at.isoformat()} UTC")
+    print()
+
+    for division in sorted(pyramid.divisions, key=lambda d: d.level):
+        header = f"Level {division.level}: {division.name}"
+        if division.short_name:
+            header += f" ({division.short_name})"
+        print(header)
+        if show_teams:
+            lines = [
+                _format_team_line(idx + 1, team.name, team.inspiration, team.location)
+                for idx, team in enumerate(division.teams)
+            ]
+            if lines:
+                print(indent("\n".join(lines), "  "))
+        print()
+
+
+def _generate_from_args(args: Namespace) -> tuple[Pyramid, int]:
+    seed = args.seed if args.seed is not None else random.randint(1, 999999)
+    pyramid = generate_pyramid(
+        level_sizes=args.levels,
+        theme=args.theme,
+        seed=seed,
+        title=args.title,
+        description=args.description,
+        custom_division_names=args.division_names,
+    )
+    return pyramid, seed
+
+
+def _handle_generate(args: Namespace) -> None:
+    pyramid, seed = _generate_from_args(args)
+    if args.preview:
+        _print_pyramid(pyramid)
+        print(f"(Preview generated with seed {seed})")
+        return
+    output_path = Path(args.output)
+    save_pyramid(pyramid, output_path)
+    print(f"Saved new pyramid to {output_path} (seed={seed})")
+
+
+def _handle_resample(args: Namespace) -> None:
+    source = Path(args.source)
+    pyramid = load_pyramid(source)
+    meta = pyramid.meta
+    theme = args.theme or meta.get("theme", "eorzea")
+    levels = args.levels or meta.get("levels")
+    if not levels:
+        raise SystemExit("The template pyramid does not contain level metadata. Provide --levels explicitly.")
+    seed = args.seed if args.seed is not None else random.randint(1, 999999)
+    division_names = args.division_names or meta.get("custom_division_names")
+    title = args.title or pyramid.title
+    description = args.description or pyramid.description
+    regenerated = generate_pyramid(
+        levels,
+        theme=theme,
+        seed=seed,
+        title=title,
+        description=description,
+        custom_division_names=division_names,
+        extra_meta={"resampled_from": str(source)},
+    )
+    if args.preview:
+        _print_pyramid(regenerated)
+        print(f"(Preview generated with seed {seed})")
+        return
+    target = Path(args.output) if args.output else source
+    save_pyramid(regenerated, target)
+    print(f"Saved regenerated pyramid to {target} (seed={seed})")
+
+
+def _handle_show(args: Namespace) -> None:
+    pyramid = load_pyramid(args.source)
+    _print_pyramid(pyramid, show_teams=not args.no_teams)
+
+
+def _handle_themes() -> None:
+    print("Available themes:\n")
+    for key, theme in sorted(THEMES.items()):
+        print(f"{key}: {theme.premier_title}")
+        print(f"  Highlight: {theme.highlight}")
+        print(f"  Sample locations: {', '.join(theme.locations[:5])}...")
+        print()
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "generate":
+        _handle_generate(args)
+    elif args.command == "resample":
+        _handle_resample(args)
+    elif args.command == "show":
+        _handle_show(args)
+    elif args.command == "themes":
+        _handle_themes()
+    else:
+        parser.error("Unknown command")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/ffxiv_pyramid/data.py
+++ b/ffxiv_pyramid/data.py
@@ -1,0 +1,263 @@
+"""Static data and helpers for FFXIV inspired content."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Represents a collection of flavour data for a pyramid theme."""
+
+    key: str
+    region_name: str
+    short_prefix: str
+    premier_title: str
+    championship_title: str
+    lower_division_title: str
+    highlight: str
+    locations: List[str]
+    mascots: List[str]
+    adjectives: List[str]
+    inspirations: List[str]
+    notes_templates: List[str]
+
+    def iter_location_cycle(self) -> Iterable[str]:
+        """Yield locations repeatedly, useful for ensuring enough clubs."""
+
+        while True:
+            for location in self.locations:
+                yield location
+
+
+THEMES: Dict[str, Theme] = {
+    "eorzea": Theme(
+        key="eorzea",
+        region_name="Eorzean",
+        short_prefix="EFL",
+        premier_title="Eorzean Premier League",
+        championship_title="Grand Company Championship",
+        lower_division_title="City-State Division",
+        highlight="The heart of the realm where Gridania, Limsa Lominsa, Ul'dah, and Ishgard compete.",
+        locations=[
+            "Gridania",
+            "Limsa Lominsa",
+            "Ul'dah",
+            "Ishgard",
+            "Sharlayan",
+            "Radz-at-Han",
+            "Mor Dhona",
+            "La Noscea",
+            "Coerthas",
+            "Thanalan",
+            "The Dravanian Forelands",
+            "Lakeland",
+            "Thavnair",
+            "Old Sharlayan",
+            "Labyrinthos",
+            "Kugane",
+            "Idyllshire",
+            "Garlemald Reclaimed",
+            "The Crystarium",
+            "Old Gridania",
+        ],
+        mascots=[
+            "Scions",
+            "Seedseers",
+            "Maelstrom",
+            "Immortals",
+            "Temple Knights",
+            "Astrologians",
+            "Nald'thal",
+            "Azure Drakes",
+            "Carbuncle",
+            "Chocobos",
+            "Free Paladins",
+            "Gobwalkers",
+            "Sky Pirates",
+            "Radiant Dawn",
+            "House Fortemps",
+            "Conjurers",
+            "Adders",
+            "Flames",
+            "Blades",
+            "Dragoons",
+        ],
+        adjectives=[
+            "Twin",
+            "Rising",
+            "Mythril",
+            "Heavensward",
+            "Stormborn",
+            "Starlit",
+            "Ruby",
+            "Umbral",
+            "Astral",
+            "Azure",
+            "Verdant",
+            "Gilded",
+            "Crystalline",
+            "Eternal",
+            "Radiant",
+        ],
+        inspirations=[
+            "Scions of the Seventh Dawn",
+            "Order of the Twin Adder",
+            "Immortal Flames",
+            "Maelstrom",
+            "Temple Knights",
+            "Ishgardian Restoration",
+            "Crystarium Guard",
+            "Students of Baldesion",
+            "Radz-at-Han alchemists",
+            "Sharlayan Forum",
+            "Bozjan Resistance",
+        ],
+        notes_templates=[
+            "Backed by the {inspiration} from {location}.",
+            "Founded by veterans of the {inspiration}.",
+            "Club culture steeped in {inspiration} tradition.",
+            "Hails from {location} with {inspiration} influence.",
+        ],
+    ),
+    "far_east": Theme(
+        key="far_east",
+        region_name="Far Eastern",
+        short_prefix="FEF",
+        premier_title="Kugane Premier Division",
+        championship_title="Hingan Championship",
+        lower_division_title="Eastern League",
+        highlight="The trading ports of Kugane, the rebel lands of Doma, and the wandering Steppe tribes collide.",
+        locations=[
+            "Kugane",
+            "Doma",
+            "Yanxia",
+            "The Azim Steppe",
+            "Hingashi",
+            "Sui-no-Sato",
+            "The Ruby Sea",
+            "Isari",
+            "Namai",
+            "Tsurumi",
+            "Shisui of the Violet Tides",
+            "Reunion",
+            "Tamamizu",
+            "Shirogane",
+            "Onokoro",
+            "Seigetsu",
+        ],
+        mascots=[
+            "Sekiseigumi",
+            "Raen",
+            "Xaela",
+            "Ruby Ronin",
+            "Steppe Riders",
+            "Doman Clans",
+            "Geiko",
+            "Raijin",
+            "Komainu",
+            "Crimson Lancers",
+            "Blue Oni",
+            "Sea Wolves",
+            "Tengu",
+            "Moonlit Ronin",
+            "Skyfarers",
+        ],
+        adjectives=[
+            "Blossom",
+            "Moonlit",
+            "Stormjade",
+            "Tempest",
+            "Crimson",
+            "Azure",
+            "Sakura",
+            "Silver",
+            "Verdant",
+            "Dragon",
+        ],
+        inspirations=[
+            "Sekiseigumi",
+            "House of the Fierce",
+            "Confederacy",
+            "Doman Liberation Front",
+            "Mol Warriors",
+            "Seiryu Temple",
+            "Tales of the Ruby Princess",
+        ],
+        notes_templates=[
+            "Backed by the {inspiration} from {location}.",
+            "Combines tactics from the {inspiration} with Far Eastern flair.",
+            "Favoured by sailors of the {inspiration}.",
+        ],
+    ),
+    "garlemald": Theme(
+        key="garlemald",
+        region_name="Imperial",
+        short_prefix="IGL",
+        premier_title="Imperial Supremacy League",
+        championship_title="Praetoriate Championship",
+        lower_division_title="Legion Divisions",
+        highlight="Reformed Garlean legions and liberated provinces contest the imperial title.",
+        locations=[
+            "Garlemald",
+            "Bozja",
+            "Werlyt",
+            "Dalmasca",
+            "Ala Mhigo",
+            "Terncliff",
+            "Paglth'an",
+            "Corvos",
+            "Iskaal",
+            "Locus Amoenus",
+            "Porta Praetoria",
+            "Tertium",
+            "Zadnor",
+        ],
+        mascots=[
+            "Magitek",
+            "Legati",
+            "Centurions",
+            "Ceruleum",
+            "Gunblades",
+            "Dreadnaughts",
+            "Praetorians",
+            "Machina",
+            "Imperial Fangs",
+            "Ala Mhigan Shields",
+            "Resistance",
+        ],
+        adjectives=[
+            "Adamant",
+            "Iron",
+            "Cerulean",
+            "Imperial",
+            "Reborn",
+            "Resolute",
+            "Steel",
+            "Vanguard",
+        ],
+        inspirations=[
+            "IVth Legion",
+            "Bozjan Resistance",
+            "Werlyt Rebellion",
+            "Dalmascan Royalists",
+            "Ala Mhigan Monks",
+            "Corvos Insurgents",
+        ],
+        notes_templates=[
+            "Former {inspiration} unit now focused on footballing glory.",
+            "Uses magitek support from {location}.",
+            "Celebrates {inspiration} heritage in every match.",
+        ],
+    ),
+}
+
+
+def get_theme(key: str) -> Theme:
+    """Retrieve a theme by key, raising a helpful error if missing."""
+
+    lowered = key.lower().replace("-", "_")
+    if lowered not in THEMES:
+        available = ", ".join(sorted(THEMES))
+        raise KeyError(f"Unknown theme '{key}'. Available themes: {available}")
+    return THEMES[lowered]

--- a/ffxiv_pyramid/generator.py
+++ b/ffxiv_pyramid/generator.py
@@ -1,0 +1,143 @@
+"""Tools to create themed football pyramids."""
+from __future__ import annotations
+
+from datetime import datetime
+import random
+from typing import List, Sequence
+
+from .data import Theme, get_theme
+from .model import Division, Pyramid, Team
+_EXTRA_TEAM_SUFFIXES = ["FC", "United", "Wanderers", "Rovers", "Dynasts", "Guard", "Club"]
+
+
+def _roman(number: int) -> str:
+    """Convert an integer into a Roman numeral."""
+
+    numerals = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+    result = []
+    remaining = number
+    for value, numeral in numerals:
+        while remaining >= value:
+            result.append(numeral)
+            remaining -= value
+    return "".join(result) if result else "I"
+
+
+def _division_name(theme: Theme, level: int, total_levels: int, custom: Sequence[str] | None = None) -> str:
+    if custom and len(custom) >= level:
+        return custom[level - 1]
+    if level == 1:
+        return theme.premier_title
+    if level == 2:
+        return theme.championship_title
+    suffix = theme.lower_division_title
+    roman_value = _roman(level - 2)
+    return f"{theme.region_name} {suffix} {roman_value}"
+
+
+def _short_name(theme: Theme, level: int) -> str:
+    return f"{theme.short_prefix} L{level}"
+
+
+def _build_team(theme: Theme, rng: random.Random, used_names: set[str]) -> Team:
+    location = rng.choice(theme.locations)
+    mascot = rng.choice(theme.mascots)
+    adjective = rng.choice(theme.adjectives)
+    base_name = f"{location} {mascot}" if rng.random() < 0.55 else f"{location} {adjective} {mascot}"
+    name = base_name
+    while name in used_names:
+        suffix = rng.choice(_EXTRA_TEAM_SUFFIXES)
+        name = f"{base_name} {suffix}"
+    used_names.add(name)
+    inspiration = rng.choice(theme.inspirations)
+    notes_template = rng.choice(theme.notes_templates)
+    notes = notes_template.format(inspiration=inspiration, location=location)
+    return Team(name=name, location=location, inspiration=inspiration, notes=notes)
+
+
+def _build_division(
+    theme: Theme,
+    level: int,
+    team_count: int,
+    total_levels: int,
+    rng: random.Random,
+    used_names: set[str],
+    custom_names: Sequence[str] | None = None,
+) -> Division:
+    name = _division_name(theme, level, total_levels, custom=custom_names)
+    short_name = _short_name(theme, level)
+    teams = [_build_team(theme, rng, used_names) for _ in range(team_count)]
+    return Division(level=level, name=name, short_name=short_name, teams=teams)
+
+
+def generate_pyramid(
+    level_sizes: Sequence[int],
+    *,
+    theme: str = "eorzea",
+    seed: int | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    custom_division_names: Sequence[str] | None = None,
+    extra_meta: dict | None = None,
+) -> Pyramid:
+    """Create a fresh pyramid using the supplied options."""
+
+    if not level_sizes:
+        raise ValueError("At least one level size is required to generate a pyramid.")
+
+    theme_obj = get_theme(theme)
+    rng = random.Random(seed)
+    used_names: set[str] = set()
+
+    divisions: List[Division] = []
+    total_levels = len(level_sizes)
+    for idx, team_count in enumerate(level_sizes, start=1):
+        division = _build_division(
+            theme_obj,
+            level=idx,
+            team_count=team_count,
+            total_levels=total_levels,
+            rng=rng,
+            used_names=used_names,
+            custom_names=custom_division_names,
+        )
+        divisions.append(division)
+
+    pyramid_title = title or f"{theme_obj.region_name} Football Pyramid"
+    pyramid_description = description or theme_obj.highlight
+
+    meta = {
+        "theme": theme_obj.key,
+        "seed": seed,
+        "levels": list(level_sizes),
+        "short_prefix": theme_obj.short_prefix,
+        "generated_using": "ffxiv_pyramid",
+    }
+    if custom_division_names:
+        meta["custom_division_names"] = list(custom_division_names)
+    if extra_meta:
+        meta.update(extra_meta)
+
+    pyramid = Pyramid(
+        title=pyramid_title,
+        description=pyramid_description,
+        divisions=divisions,
+        meta=meta,
+        generated_at=datetime.utcnow(),
+    )
+    pyramid.sort()
+    return pyramid

--- a/ffxiv_pyramid/io.py
+++ b/ffxiv_pyramid/io.py
@@ -1,0 +1,97 @@
+"""Serialization helpers for pyramids."""
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .model import Division, Pyramid, Team
+
+
+def pyramid_to_dict(pyramid: Pyramid) -> Dict[str, Any]:
+    """Convert a :class:`Pyramid` into a JSON serialisable dict."""
+
+    return {
+        "title": pyramid.title,
+        "description": pyramid.description,
+        "generated_at": pyramid.generated_at.isoformat() if pyramid.generated_at else None,
+        "meta": pyramid.meta,
+        "divisions": [
+            {
+                "level": division.level,
+                "name": division.name,
+                "short_name": division.short_name,
+                "teams": [
+                    {
+                        "name": team.name,
+                        "location": team.location,
+                        "inspiration": team.inspiration,
+                        "notes": team.notes,
+                    }
+                    for team in division.teams
+                ],
+            }
+            for division in pyramid.divisions
+        ],
+    }
+
+
+def dict_to_pyramid(data: Dict[str, Any]) -> Pyramid:
+    """Reconstruct a :class:`Pyramid` from the serialised form."""
+
+    divisions = []
+    for division_data in data.get("divisions", []):
+        teams = [
+            Team(
+                name=team_data["name"],
+                location=team_data.get("location", ""),
+                inspiration=team_data.get("inspiration", ""),
+                notes=team_data.get("notes"),
+            )
+            for team_data in division_data.get("teams", [])
+        ]
+        divisions.append(
+            Division(
+                level=int(division_data["level"]),
+                name=division_data["name"],
+                short_name=division_data.get("short_name"),
+                teams=teams,
+            )
+        )
+    generated_at = data.get("generated_at")
+    if generated_at:
+        generated_at = datetime.fromisoformat(generated_at)
+    else:
+        generated_at = None
+
+    pyramid = Pyramid(
+        title=data.get("title", "Unnamed Pyramid"),
+        description=data.get("description", ""),
+        divisions=divisions,
+        meta=data.get("meta", {}),
+        generated_at=generated_at,
+    )
+    pyramid.sort()
+    return pyramid
+
+
+def save_pyramid(pyramid: Pyramid, path: str | Path) -> Path:
+    """Serialise the pyramid to JSON on disk."""
+
+    target = Path(path)
+    if target.suffix.lower() != ".json":
+        raise ValueError("The app currently writes JSON. Use a .json file extension.")
+    payload = pyramid_to_dict(pyramid)
+    target.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return target
+
+
+def load_pyramid(path: str | Path) -> Pyramid:
+    """Load a pyramid definition from disk."""
+
+    source = Path(path)
+    if not source.exists():
+        raise FileNotFoundError(f"Pyramid file not found: {source}")
+    data = json.loads(source.read_text(encoding="utf-8"))
+    return dict_to_pyramid(data)

--- a/ffxiv_pyramid/model.py
+++ b/ffxiv_pyramid/model.py
@@ -1,0 +1,44 @@
+"""Data models for the FFXIV football pyramid app."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Team:
+    """Represents a club participating in the pyramid."""
+
+    name: str
+    location: str
+    inspiration: str
+    notes: Optional[str] = None
+
+
+@dataclass
+class Division:
+    """Represents a level within the football pyramid."""
+
+    level: int
+    name: str
+    short_name: Optional[str] = None
+    teams: List[Team] = field(default_factory=list)
+
+
+@dataclass
+class Pyramid:
+    """Container that describes the full pyramid."""
+
+    title: str
+    description: str
+    divisions: List[Division]
+    meta: Dict[str, Any] = field(default_factory=dict)
+    generated_at: datetime | None = None
+
+    def sort(self) -> None:
+        """Ensure divisions are sorted by level and teams alphabetically."""
+
+        self.divisions.sort(key=lambda d: d.level)
+        for division in self.divisions:
+            division.teams.sort(key=lambda t: t.name)


### PR DESCRIPTION
## Summary
- add an `ffxiv_pyramid` package with data models, generator logic, and a command line interface
- provide curated Eorzean, Far Eastern, and Garlean themes with team name generation helpers
- document the workflow and include an example JSON pyramid for quick iteration

## Testing
- python -m ffxiv_pyramid.cli themes
- python -m ffxiv_pyramid.cli generate examples/eorzea_pyramid.json --levels 12 12 18 24 --theme eorzea --title "Hydaelyn League System" --description "An example four-tier pyramid spanning the Source." --seed 123
- python -m ffxiv_pyramid.cli show examples/eorzea_pyramid.json --no-teams

------
https://chatgpt.com/codex/tasks/task_e_68cff6bcf1dc832a806f7d2e9aaa09d1