### PR TITLE
Add fm26_auto_editor command line tool

### DIFF
--- a/fm26_auto_editor/__init__.py
+++ b/fm26_auto_editor/__init__.py
@@ -1,0 +1,12 @@
+"""Top-level package for fm26_auto_editor.
+
+This package provides utilities to automate editing Football Manager 2026
+Pre-Game Editor XML data files using CSV inputs. The package exposes a command
+line interface via :mod:`fm26_auto_editor.cli`.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/fm26_auto_editor/__main__.py
+++ b/fm26_auto_editor/__main__.py
@@ -1,0 +1,17 @@
+"""Module entry point for ``python -m fm26_auto_editor``."""
+
+from __future__ import annotations
+
+import sys
+
+from .cli import main
+
+
+def run() -> None:
+    """Execute the command line interface and exit with its status code."""
+
+    sys.exit(main())
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    run()

--- a/fm26_auto_editor/changes.py
+++ b/fm26_auto_editor/changes.py
@@ -1,0 +1,103 @@
+"""Helpers for constructing Football Manager editor change records."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from xml.etree import ElementTree as ET
+
+from .utils import make_db_random_id
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _base_change_record(
+    db_changes: ET.Element,
+    table_type: int,
+    uid: int,
+    property_id: int,
+    version: int,
+) -> ET.Element:
+    """Create a new change ``<record>`` element with shared fields populated."""
+
+    record = ET.SubElement(db_changes, "record")
+    ET.SubElement(record, "integer", {"id": "database_table_type", "value": str(table_type)})
+    ET.SubElement(record, "large", {"id": "db_unique_id", "value": str(uid)})
+    ET.SubElement(record, "unsigned", {"id": "property", "value": str(property_id)})
+    ET.SubElement(record, "integer", {"id": "version", "value": str(version)})
+    LOGGER.debug(
+        "Created base change record table=%s uid=%s property=%s version=%s",
+        table_type,
+        uid,
+        property_id,
+        version,
+    )
+    return record
+
+
+def _attach_random_id(record: ET.Element, uid: int, property_id: int, new_value: str | int) -> None:
+    """Attach a ``db_random_id`` element to *record* using a stable hash."""
+
+    random_id = make_db_random_id(uid=uid, property_id=property_id, new_value=new_value)
+    ET.SubElement(record, "integer", {"id": "db_random_id", "value": str(random_id)})
+    LOGGER.debug("Attached db_random_id=%s", random_id)
+
+
+def add_string_change(
+    db_changes: ET.Element,
+    table_type: int,
+    uid: int,
+    property_id: int,
+    new_value: str,
+    version: int,
+    old_value: Optional[str] = None,
+) -> ET.Element:
+    """Append a string change record to *db_changes* and return it."""
+
+    record = _base_change_record(db_changes, table_type, uid, property_id, version)
+    ET.SubElement(record, "string", {"id": "new_value", "value": new_value})
+    if old_value is not None:
+        ET.SubElement(record, "string", {"id": "odvl", "value": old_value})
+    ET.SubElement(record, "boolean", {"id": "is_client_field", "value": "true"})
+    ET.SubElement(record, "boolean", {"id": "is_language_field", "value": "true"})
+    _attach_random_id(record, uid, property_id, new_value)
+    LOGGER.info(
+        "Queued string change table=%s uid=%s property=%s value=%s",
+        table_type,
+        uid,
+        property_id,
+        new_value,
+    )
+    return record
+
+
+def add_int_change(
+    db_changes: ET.Element,
+    table_type: int,
+    uid: int,
+    property_id: int,
+    new_value: int,
+    version: int,
+    old_value: Optional[int] = None,
+) -> ET.Element:
+    """Append an integer change record to *db_changes* and return it."""
+
+    record = _base_change_record(db_changes, table_type, uid, property_id, version)
+    ET.SubElement(record, "integer", {"id": "new_value", "value": str(new_value)})
+    if old_value is not None:
+        ET.SubElement(record, "integer", {"id": "odvl", "value": str(old_value)})
+    _attach_random_id(record, uid, property_id, new_value)
+    LOGGER.info(
+        "Queued integer change table=%s uid=%s property=%s value=%s",
+        table_type,
+        uid,
+        property_id,
+        new_value,
+    )
+    return record
+
+
+__all__ = [
+    "add_string_change",
+    "add_int_change",
+]

--- a/fm26_auto_editor/cli.py
+++ b/fm26_auto_editor/cli.py
@@ -1,0 +1,155 @@
+"""fm26_auto_editor command line interface.
+
+This tool automates appending change records to Football Manager 2026
+Pre-Game Editor XML files. Provide the base editor data export along with CSV
+files describing the desired modifications. The tool converts each CSV row into
+an XML ``<record>`` under ``<list id="db_changes">`` ready to re-import via the
+Football Manager Pre-Game Editor.
+
+Usage
+-----
+Run the tool via the module entry point::
+
+    python -m fm26_auto_editor \
+        --base-xml EorzeanFootball.xml \
+        --out-xml EorzeanFootball_out.xml \
+        --competitions-csv competitions.csv \
+        --clubs-csv clubs.csv \
+        --nations-csv nations.csv \
+        --continents-csv continents.csv
+
+Use ``--dry-run`` to preview how many changes would be generated without writing
+an output file. CSV files must include the headers outlined in the project
+requirements.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from typing import Dict, Iterable, Optional
+
+from .importers import (
+    apply_club_changes_from_csv,
+    apply_competition_changes_from_csv,
+    apply_continent_changes_from_csv,
+    apply_nation_changes_from_csv,
+)
+from .utils import configure_logging
+from .xml_model import (
+    EditorDataError,
+    get_db_changes_list,
+    get_root_and_version,
+    load_editor_xml,
+    write_editor_xml,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+CATEGORY_APPLIERS = {
+    "competitions": apply_competition_changes_from_csv,
+    "clubs": apply_club_changes_from_csv,
+    "nations": apply_nation_changes_from_csv,
+    "continents": apply_continent_changes_from_csv,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the :class:`argparse.ArgumentParser` used by the CLI."""
+
+    parser = argparse.ArgumentParser(
+        prog="fm26_auto_editor",
+        description="Append Football Manager 2026 editor change records from CSV files.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--base-xml", required=True, help="Path to the base editor XML file")
+    parser.add_argument(
+        "--out-xml",
+        required=True,
+        help="Destination path for the updated editor XML file",
+    )
+    parser.add_argument("--competitions-csv", help="CSV describing competition changes")
+    parser.add_argument("--clubs-csv", help="CSV describing club changes")
+    parser.add_argument("--nations-csv", help="CSV describing nation changes")
+    parser.add_argument("--continents-csv", help="CSV describing continent changes")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate change records but do not write the output file",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase logging verbosity (can be specified multiple times)",
+    )
+    return parser
+
+
+def _collect_csv_args(args: argparse.Namespace) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for category in CATEGORY_APPLIERS:
+        attr = f"{category}_csv"
+        value = getattr(args, attr)
+        if value:
+            mapping[category] = value
+    return mapping
+
+
+def _print_summary(changes_by_category: Dict[str, int]) -> None:
+    lines = ["Change summary (dry-run):"]
+    for category in CATEGORY_APPLIERS:
+        count = changes_by_category.get(category, 0)
+        lines.append(f"  {category}: {count}")
+    print("\n".join(lines))
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """Entry point for the ``fm26_auto_editor`` command line interface."""
+
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    configure_logging(args.verbose)
+
+    try:
+        tree = load_editor_xml(args.base_xml)
+    except FileNotFoundError as exc:
+        LOGGER.error("%s", exc)
+        return 1
+
+    try:
+        root, version = get_root_and_version(tree)
+    except EditorDataError as exc:
+        LOGGER.error("%s", exc)
+        return 1
+
+    db_changes = get_db_changes_list(root)
+    csv_args = _collect_csv_args(args)
+
+    if not csv_args:
+        LOGGER.warning("No CSV files provided; nothing to do")
+
+    changes_by_category: Dict[str, int] = {}
+    for category, csv_path in csv_args.items():
+        applier = CATEGORY_APPLIERS[category]
+        LOGGER.info("Applying %s changes from %s", category, csv_path)
+        changes_by_category[category] = applier(db_changes, version, csv_path)
+
+    if args.dry_run:
+        _print_summary(changes_by_category)
+        return 0
+
+    try:
+        write_editor_xml(tree, args.out_xml)
+    except OSError as exc:
+        LOGGER.error("Failed to write output XML: %s", exc)
+        return 1
+
+    LOGGER.info("Wrote updated editor data to %s", args.out_xml)
+    return 0
+
+
+__all__ = ["build_parser", "main"]

--- a/fm26_auto_editor/constants.py
+++ b/fm26_auto_editor/constants.py
@@ -1,0 +1,77 @@
+"""Database table type and property ID constants for Football Manager 2026.
+
+The numeric identifiers defined here mirror those used by the Football Manager
+Pre-Game Editor when exporting XML data files. Keeping them in a dedicated
+module makes it easier to reference and extend as additional object types or
+properties are supported by :mod:`fm26_auto_editor`.
+"""
+
+from __future__ import annotations
+
+# Database table types -------------------------------------------------------
+
+# NOTE: Table type identifiers are determined by Sports Interactive's internal
+# schema. They are included here verbatim so that the editor can target the
+# correct table within the FM database when creating change records.
+TABLE_CITY: int = 2
+TABLE_CLUB: int = 3
+TABLE_CONTINENT: int = 5
+TABLE_MEDIA: int = 7
+TABLE_NATION: int = 10
+TABLE_COMPETITION: int = 25
+TABLE_REGION: int = 27
+
+# Club property identifiers --------------------------------------------------
+
+# These property IDs correspond to specific club fields. Only a subset that is
+# required for the initial version of the tool is included.
+PROP_CLUB_LONG_NAME: int = 1_131_307_373
+PROP_CLUB_SHORT_NAME: int = 1_131_638_381
+PROP_CLUB_ABBR3_A: int = 1_131_640_942
+PROP_CLUB_ABBR3_B: int = 1_131_164_526
+PROP_CLUB_ABBR2: int = 1_130_443_630
+PROP_CLUB_TAG: int = 1_413_703_796
+PROP_CLUB_VAL1: int = 1_130_586_721
+PROP_CLUB_VAL2: int = 1_131_700_853
+PROP_CLUB_VAL3: int = 1_131_572_578
+
+# Competition property identifiers ------------------------------------------
+PROP_COMP_FULL_NAME: int = 1_668_178_285
+PROP_COMP_ALT_NAME: int = 1_668_509_293
+PROP_COMP_SHORT_NAME: int = 1_664_314_478
+
+# Nation property identifiers ------------------------------------------------
+PROP_NATION_NAME: int = 1_315_856_749
+PROP_NATION_SHORT: int = 1_316_187_757
+PROP_NATION_CODE3: int = 1_311_992_942
+PROP_NATION_ADJ: int = 1_315_861_625
+
+# Continent property identifiers --------------------------------------------
+PROP_CONT_NAME: int = 1_131_307_373
+
+__all__ = [
+    "TABLE_CITY",
+    "TABLE_CLUB",
+    "TABLE_CONTINENT",
+    "TABLE_MEDIA",
+    "TABLE_NATION",
+    "TABLE_COMPETITION",
+    "TABLE_REGION",
+    "PROP_CLUB_LONG_NAME",
+    "PROP_CLUB_SHORT_NAME",
+    "PROP_CLUB_ABBR3_A",
+    "PROP_CLUB_ABBR3_B",
+    "PROP_CLUB_ABBR2",
+    "PROP_CLUB_TAG",
+    "PROP_CLUB_VAL1",
+    "PROP_CLUB_VAL2",
+    "PROP_CLUB_VAL3",
+    "PROP_COMP_FULL_NAME",
+    "PROP_COMP_ALT_NAME",
+    "PROP_COMP_SHORT_NAME",
+    "PROP_NATION_NAME",
+    "PROP_NATION_SHORT",
+    "PROP_NATION_CODE3",
+    "PROP_NATION_ADJ",
+    "PROP_CONT_NAME",
+]

--- a/fm26_auto_editor/importers.py
+++ b/fm26_auto_editor/importers.py
@@ -1,0 +1,300 @@
+"""CSV importers that translate rows into Football Manager change records."""
+
+from __future__ import annotations
+
+import csv
+import logging
+from pathlib import Path
+from typing import Iterable, List, Tuple
+from xml.etree import ElementTree as ET
+
+from . import constants
+from .changes import add_int_change, add_string_change
+from .utils import normalise_optional, parse_int
+
+LOGGER = logging.getLogger(__name__)
+
+Row = Tuple[int, dict[str, str]]
+
+
+def _iter_rows(csv_path: Path) -> Iterable[Row]:
+    """Yield ``(line_number, row_dict)`` tuples for each row in *csv_path*."""
+
+    with csv_path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for index, row in enumerate(reader, start=2):
+            LOGGER.debug("Processing row %s from %s", index, csv_path)
+            yield index, row
+
+
+def _load_rows(csv_path: str) -> List[Row]:
+    path = Path(csv_path)
+    if not path.exists():
+        LOGGER.error("CSV file not found: %s", csv_path)
+        return []
+    return list(_iter_rows(path))
+
+
+def apply_competition_changes_from_csv(db_changes: ET.Element, version: int, csv_path: str) -> int:
+    """Apply competition changes from *csv_path* and return the number of edits."""
+
+    count = 0
+    for line_no, row in _load_rows(csv_path):
+        uid = parse_int(row.get("competition_uid"))
+        if uid is None:
+            LOGGER.error("Invalid or missing competition_uid on line %s in %s", line_no, csv_path)
+            continue
+        full_name = normalise_optional(row.get("full_name"))
+        alt_name = normalise_optional(row.get("alt_name"))
+        short_name = normalise_optional(row.get("short_name"))
+
+        if full_name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_COMPETITION,
+                uid,
+                constants.PROP_COMP_FULL_NAME,
+                full_name,
+                version,
+            )
+            count += 1
+            alt_for_property = alt_name or full_name
+            add_string_change(
+                db_changes,
+                constants.TABLE_COMPETITION,
+                uid,
+                constants.PROP_COMP_ALT_NAME,
+                alt_for_property,
+                version,
+            )
+            count += 1
+        elif alt_name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_COMPETITION,
+                uid,
+                constants.PROP_COMP_ALT_NAME,
+                alt_name,
+                version,
+            )
+            count += 1
+
+        if short_name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_COMPETITION,
+                uid,
+                constants.PROP_COMP_SHORT_NAME,
+                short_name,
+                version,
+            )
+            count += 1
+
+    LOGGER.info("Applied %s competition changes from %s", count, csv_path)
+    return count
+
+
+def apply_club_changes_from_csv(db_changes: ET.Element, version: int, csv_path: str) -> int:
+    """Apply club changes from *csv_path* and return the number of edits."""
+
+    count = 0
+    for line_no, row in _load_rows(csv_path):
+        uid = parse_int(row.get("club_uid"))
+        if uid is None:
+            LOGGER.error("Invalid or missing club_uid on line %s in %s", line_no, csv_path)
+            continue
+
+        long_name = normalise_optional(row.get("long_name"))
+        short_name = normalise_optional(row.get("short_name"))
+        short_code3 = normalise_optional(row.get("short_code3"))
+        short_code2 = normalise_optional(row.get("short_code2"))
+        tag = normalise_optional(row.get("tag"))
+        val1 = parse_int(row.get("val1"))
+        val2 = parse_int(row.get("val2"))
+        val3 = parse_int(row.get("val3"))
+
+        if long_name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_LONG_NAME,
+                long_name,
+                version,
+            )
+            count += 1
+        if short_name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_SHORT_NAME,
+                short_name,
+                version,
+            )
+            count += 1
+        if short_code3:
+            add_string_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_ABBR3_A,
+                short_code3,
+                version,
+            )
+            add_string_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_ABBR3_B,
+                short_code3,
+                version,
+            )
+            count += 2
+        if short_code2:
+            add_string_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_ABBR2,
+                short_code2,
+                version,
+            )
+            count += 1
+        if tag:
+            add_string_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_TAG,
+                tag,
+                version,
+            )
+            count += 1
+        if val1 is not None:
+            add_int_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_VAL1,
+                val1,
+                version,
+            )
+            count += 1
+        if val2 is not None:
+            add_int_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_VAL2,
+                val2,
+                version,
+            )
+            count += 1
+        if val3 is not None:
+            add_int_change(
+                db_changes,
+                constants.TABLE_CLUB,
+                uid,
+                constants.PROP_CLUB_VAL3,
+                val3,
+                version,
+            )
+            count += 1
+
+    LOGGER.info("Applied %s club changes from %s", count, csv_path)
+    return count
+
+
+def apply_nation_changes_from_csv(db_changes: ET.Element, version: int, csv_path: str) -> int:
+    """Apply nation changes from *csv_path* and return the number of edits."""
+
+    count = 0
+    for line_no, row in _load_rows(csv_path):
+        uid = parse_int(row.get("nation_uid"))
+        if uid is None:
+            LOGGER.error("Invalid or missing nation_uid on line %s in %s", line_no, csv_path)
+            continue
+
+        name = normalise_optional(row.get("name"))
+        short_name = normalise_optional(row.get("short_name"))
+        three_letter = normalise_optional(row.get("three_letter"))
+        adjective = normalise_optional(row.get("adjective"))
+
+        if name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_NATION,
+                uid,
+                constants.PROP_NATION_NAME,
+                name,
+                version,
+            )
+            count += 1
+        if short_name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_NATION,
+                uid,
+                constants.PROP_NATION_SHORT,
+                short_name,
+                version,
+            )
+            count += 1
+        if three_letter:
+            add_string_change(
+                db_changes,
+                constants.TABLE_NATION,
+                uid,
+                constants.PROP_NATION_CODE3,
+                three_letter,
+                version,
+            )
+            count += 1
+        if adjective:
+            add_string_change(
+                db_changes,
+                constants.TABLE_NATION,
+                uid,
+                constants.PROP_NATION_ADJ,
+                adjective,
+                version,
+            )
+            count += 1
+
+    LOGGER.info("Applied %s nation changes from %s", count, csv_path)
+    return count
+
+
+def apply_continent_changes_from_csv(db_changes: ET.Element, version: int, csv_path: str) -> int:
+    """Apply continent changes from *csv_path* and return the number of edits."""
+
+    count = 0
+    for line_no, row in _load_rows(csv_path):
+        uid = parse_int(row.get("continent_uid"))
+        if uid is None:
+            LOGGER.error("Invalid or missing continent_uid on line %s in %s", line_no, csv_path)
+            continue
+
+        name = normalise_optional(row.get("name"))
+        if name:
+            add_string_change(
+                db_changes,
+                constants.TABLE_CONTINENT,
+                uid,
+                constants.PROP_CONT_NAME,
+                name,
+                version,
+            )
+            count += 1
+
+    LOGGER.info("Applied %s continent changes from %s", count, csv_path)
+    return count
+
+
+__all__ = [
+    "apply_competition_changes_from_csv",
+    "apply_club_changes_from_csv",
+    "apply_nation_changes_from_csv",
+    "apply_continent_changes_from_csv",
+]

--- a/fm26_auto_editor/utils.py
+++ b/fm26_auto_editor/utils.py
@@ -1,0 +1,84 @@
+"""Utility helpers for :mod:`fm26_auto_editor`.
+
+This module centralises functionality that is reused across the package, such as
+logging configuration, string normalisation helpers, and stable random number
+generation for change records.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sys
+from typing import Optional
+
+_LOGGER_INITIALISED: bool = False
+
+
+def configure_logging(verbosity: int = 0) -> None:
+    """Configure logging for the application.
+
+    Parameters
+    ----------
+    verbosity:
+        Verbosity level from the command line. ``0`` configures :mod:`logging`
+        at :data:`logging.INFO`; higher values increase verbosity to
+        :data:`logging.DEBUG`.
+    """
+
+    global _LOGGER_INITIALISED
+
+    if _LOGGER_INITIALISED:
+        logging.getLogger(__name__).debug("Logging already initialised")
+        return
+
+    level = logging.DEBUG if verbosity > 0 else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s | %(name)s | %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+    _LOGGER_INITIALISED = True
+
+
+def normalise_optional(value: Optional[str]) -> Optional[str]:
+    """Return the stripped value or ``None`` if the input is empty."""
+
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def parse_int(value: Optional[str]) -> Optional[int]:
+    """Parse *value* into an integer, returning ``None`` on failure."""
+
+    if value is None:
+        return None
+    try:
+        return int(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def make_db_random_id(uid: int, property_id: int, new_value: str | int) -> int:
+    """Generate a stable pseudo-random integer for change records.
+
+    The Football Manager editor expects each record to include a ``db_random_id``
+    value. The editor typically provides this value automatically, but when
+    generating records programmatically we mimic the behaviour by hashing the
+    tuple ``(uid, property_id, new_value)`` using SHA-1 and converting the first
+    four bytes of the digest to a positive integer.
+    """
+
+    seed = f"{uid}-{property_id}-{new_value}".encode("utf-8")
+    digest = hashlib.sha1(seed).digest()
+    return int.from_bytes(digest[:4], byteorder="big", signed=False)
+
+
+__all__ = [
+    "configure_logging",
+    "normalise_optional",
+    "parse_int",
+    "make_db_random_id",
+]

--- a/fm26_auto_editor/xml_model.py
+++ b/fm26_auto_editor/xml_model.py
@@ -1,0 +1,77 @@
+"""XML parsing and writing helpers for Football Manager editor files."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Tuple
+from xml.etree import ElementTree as ET
+
+LOGGER = logging.getLogger(__name__)
+
+
+class EditorDataError(RuntimeError):
+    """Raised when the base editor XML file does not match expectations."""
+
+
+def load_editor_xml(path: str | Path) -> ET.ElementTree:
+    """Load the Football Manager editor XML file located at *path*."""
+
+    xml_path = Path(path)
+    if not xml_path.exists():
+        raise FileNotFoundError(f"Base XML file not found: {xml_path}")
+    LOGGER.debug("Loading XML file %s", xml_path)
+    return ET.parse(xml_path)
+
+
+def get_root_and_version(tree: ET.ElementTree) -> Tuple[ET.Element, int]:
+    """Return the root ``<record>`` element and database version integer."""
+
+    root = tree.getroot()
+    if root.tag != "record":
+        raise EditorDataError("Root element is not <record> as expected")
+
+    for child in root.findall("integer"):
+        if child.get("id") == "version":
+            value = child.get("value")
+            if value is None:
+                break
+            try:
+                version = int(value)
+            except ValueError as exc:  # pragma: no cover - defensive programming
+                raise EditorDataError("Version value is not an integer") from exc
+            LOGGER.debug("Detected database version: %s", version)
+            return root, version
+
+    raise EditorDataError("Base XML does not include an <integer id=\"version\"> element")
+
+
+def get_db_changes_list(root: ET.Element) -> ET.Element:
+    """Return the ``<list id="db_changes">`` element, creating it if missing."""
+
+    for child in root.findall("list"):
+        if child.get("id") == "db_changes":
+            LOGGER.debug("Found existing db_changes list with %s children", len(child))
+            return child
+
+    LOGGER.info("db_changes list missing; creating new list element")
+    db_changes = ET.SubElement(root, "list", {"id": "db_changes"})
+    return db_changes
+
+
+def write_editor_xml(tree: ET.ElementTree, path: str | Path) -> None:
+    """Write *tree* to *path* using UTF-16 encoding and an XML declaration."""
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    LOGGER.debug("Writing updated XML to %s", output_path)
+    tree.write(output_path, encoding="utf-16", xml_declaration=True)
+
+
+__all__ = [
+    "EditorDataError",
+    "load_editor_xml",
+    "get_root_and_version",
+    "get_db_changes_list",
+    "write_editor_xml",
+]

--- a/main.py
+++ b/main.py
@@ -1,0 +1,11 @@
+"""Executable entry point for fm26_auto_editor."""
+
+from __future__ import annotations
+
+import sys
+
+from fm26_auto_editor.cli import main as cli_main
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    sys.exit(cli_main())


### PR DESCRIPTION
## Summary
- add the `fm26_auto_editor` package with constants, XML helpers, change record builders, and CSV importers
- implement an argparse-driven CLI with dry-run support and logging configuration
- provide a top-level `main.py` entry point for running the tool from the repository root

## Testing
- python -m compileall fm26_auto_editor main.py

------
https://chatgpt.com/codex/tasks/task_e_690b70374e60832aba65bcf6c2595d1c